### PR TITLE
Http chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2954,7 +2954,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "tezedge_proxy"
+name = "tezedge_debugger"
 version = "0.1.0"
 dependencies = [
  "argh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tezedge_proxy"
+name = "tezedge_debugger"
 version = "0.1.0"
 authors = ["Martin Lacko <martin.lacko@simplestaking.com>"]
 edition = "2018"

--- a/docker.sh
+++ b/docker.sh
@@ -47,7 +47,7 @@ if [ ! -d "/var/run/netns" ]; then
 fi
 
 docker pull simplestakingcom/tezedge-tezos:latest
-docker pull simplestakingcom/tezedge-debuger:latest
+#docker pull simplestakingcom/tezedge-debuger:latest
 docker pull simplestakingcom/tezedge-explorer-ocaml
 
 # Check identity

--- a/docker.sh
+++ b/docker.sh
@@ -47,7 +47,7 @@ if [ ! -d "/var/run/netns" ]; then
 fi
 
 docker pull simplestakingcom/tezedge-tezos:latest
-#docker pull simplestakingcom/tezedge-debuger:latest
+docker pull simplestakingcom/tezedge-debuger:latest
 docker pull simplestakingcom/tezedge-explorer-ocaml
 
 # Check identity

--- a/src/storage/rpc_message.rs
+++ b/src/storage/rpc_message.rs
@@ -131,7 +131,7 @@ impl From<RESTMessage> for MappedRESTMessage {
     fn from(value: RESTMessage) -> Self {
         match value {
             RESTMessage::Response { status, payload } => Self::Response { status, payload },
-            RESTMessage::Request { method, path, payload } => Self::Request { method, path, payload }
+            RESTMessage::Request { method, path, payload } => Self::Request { method, path, payload },
         }
     }
 }


### PR DESCRIPTION
Updated method, how HTTP packets are parsed and processed, to allow `transfer-encoding: chunked` work properly, even when segmented.